### PR TITLE
Update Honda Prologue generations: Add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Honda Prologue
 
+This repository contains signal set configurations for the Honda Prologue, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Honda Prologue.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Honda_Prologue"
+
 generations:
   - name: "First Generation"
     start_year: 2024


### PR DESCRIPTION
- Added references array to generations.yaml with Honda Prologue Wikipedia URL
- README.md was minimal placeholder - updated with standard template
- Current generation data accurate: First Generation (2024-present)
